### PR TITLE
Use PCIDevice `.status.resourceName` property for KubeVirt device names

### DIFF
--- a/pkg/harvester/dialog/RestoreSnapshotDialog.vue
+++ b/pkg/harvester/dialog/RestoreSnapshotDialog.vue
@@ -4,7 +4,7 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
-import { LabeledInput } from '@components/form/LabeledInput';
+import { LabeledInput } from '@components/Form/LabeledInput';
 export default {
   name:       'HarvesterRestoreSnapshotDialog',
   components: {

--- a/pkg/harvester/edit/harvesterhci.io.volumesnapshot.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volumesnapshot.vue
@@ -2,7 +2,7 @@
 import Tab from '@shell/components/Tabbed/Tab';
 import CruResource from '@shell/components/CruResource';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
-import { LabeledInput } from '@components/form/LabeledInput';
+import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { get } from '@shell/utils/object';
 import { HCI } from '../types';

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
@@ -58,7 +58,7 @@ export default {
     selectedDevices(neu) {
       const formatted = neu.map((deviceUid, idx) => {
         const deviceCRD = this.uniqueDevices[deviceUid].deviceCRDs[0];
-        const deviceName = deviceCRD?.status?.description;
+        const deviceName = deviceCRD?.status?.resourceName;
 
         return {
           deviceName,


### PR DESCRIPTION
**- What I did**

* Changes to reflect https://github.com/harvester/pcidevices/pull/6
* Fixed component import typos